### PR TITLE
Port Rez format writer from old KDK

### DIFF
--- a/libGraphite/rsrc/rez.cpp
+++ b/libGraphite/rsrc/rez.cpp
@@ -34,5 +34,98 @@ auto graphite::rsrc::rez::parse(std::shared_ptr<graphite::data::reader> reader) 
 
 auto graphite::rsrc::rez::write(const std::string& path, std::vector<std::shared_ptr<graphite::rsrc::type>> types) -> void
 {
-    // TODO: .rez implementation
+    auto writer = std::make_shared<graphite::data::writer>();
+    writer->data()->set_byte_order(graphite::data::data::byte_order::lsb);
+
+    const std::string rez_signature = "BRGR";
+    const std::string map_name = "resource.map";
+    const uint32_t rez_version = 1;
+    const uint32_t resource_offset_length = 12;
+    const uint32_t map_header_length = 8;
+    const uint32_t type_info_length = 12;
+    const uint32_t resource_info_length = 266;
+
+    // Count up the total number of resources
+    uint32_t resource_count = 0;
+    for (auto type : types) {
+        resource_count += type->count();
+    }
+
+    // The resource map itself is considered an entry for the offsets in the header
+    uint32_t entry_count = resource_count + 1;
+
+    // Calculate header length - this is from the end of the preamble to the start of the resource data
+    uint32_t header_length = 12 + (entry_count * resource_offset_length) + map_name.size()+1;
+
+    // Write the preamble
+    writer->write_cstr(rez_signature, 4);
+    writer->write_long(rez_version);
+    writer->write_long(header_length);
+
+    // Calculate the offset to the first resource data
+    uint32_t resource_offset = static_cast<uint32_t>(writer->size()) + header_length;
+
+    // Write the header
+    uint32_t index = 1; // Index of first resource, starting at 1
+    writer->write_long(1); // Unknown value
+    writer->write_long(index);
+    writer->write_long(entry_count);
+    for (auto type : types) {
+        for (auto resource : type->resources()) {
+            // Get the data for the resource and determine its size.
+            auto data = resource->data();
+            auto size = data->size();
+            writer->write_long(resource_offset);
+            writer->write_long(static_cast<uint32_t>(size));
+            writer->write_long(0); // Unknown value
+            resource_offset += size;
+        }
+    }
+
+    uint32_t type_count = types.size();
+    // Calculate offset within map to start of resource info
+    uint32_t type_offset = map_header_length + (type_count * type_info_length);
+    uint32_t map_length = type_offset + (resource_count * resource_info_length);
+    // Write the offset and size of the resource map
+    writer->write_long(resource_offset);
+    writer->write_long(map_length);
+    writer->write_long(12 + (entry_count * resource_offset_length)); // Unknown value
+
+    // Write the name of the resource map
+    writer->write_cstr(map_name);
+
+    // Write each resource
+    for (auto type : types) {
+        for (auto resource : type->resources()) {
+            writer->write_data(resource->data());
+        }
+    }
+
+    // Write the resource map as big endian
+    // Map header
+    writer->data()->set_byte_order(graphite::data::data::byte_order::msb);
+    writer->write_long(8); // Unknown value
+    writer->write_long(type_count);
+
+    // Type counts and offsets
+    for (auto type : types) {
+        auto count = type->count();
+        writer->write_cstr(type->code(), 4);
+        writer->write_long(type_offset);
+        writer->write_long(count);
+        type_offset += resource_info_length * count;
+    }
+
+    // Info for each resource
+    for (auto type : types) {
+        for (auto resource : type->resources()) {
+            writer->write_long(index++);
+            writer->write_cstr(type->code(), 4);
+            writer->write_signed_short(static_cast<int16_t>(resource->id()));
+            writer->write_cstr(resource->name(), 256);
+        }
+    }
+
+    // Finish by writing the contents of the Rez file to disk.
+    writer->save(path);
 }


### PR DESCRIPTION
Original code is available at https://github.com/andrews05/kestrel-development-kit/blob/fb2b8e699a017c9561ae369fe387cc724df4cfeb/kas/rsrc/file.cpp#L363-L457

I tested this using the following Cron resource definition:

```
declare Cron {
    new (#128, "Example Event") {
        FirstDate = 01 01 3100;
        LastDate = 31 12 3100;
        Random = 50%;
        Duration = 7;
    };
};
```

The resulting Rez file is available [here](https://github.com/TheDiamondProject/Graphite/files/4496009/CronExample.zip); it is read successfully by EVNEW:

<img width="501" alt="cronexample" src="https://user-images.githubusercontent.com/148661/79627457-af495280-817b-11ea-93f4-a9adf560cb65.png">

