### PR TITLE
Add Nova sound resource support

### DIFF
--- a/libGraphite/resources/sound.cpp
+++ b/libGraphite/resources/sound.cpp
@@ -1,0 +1,281 @@
+//
+// Created by Tom Hancocks on 24/03/2020.
+//
+
+#include "libGraphite/resources/sound.hpp"
+#include "libGraphite/rsrc/manager.hpp"
+#include "libGraphite/data/reader.hpp"
+#import <algorithm>
+
+// MARK: - IMA4 Decoding
+
+// Refer to https://wiki.multimedia.cx/index.php?title=IMA_ADPCM,
+// http://www.cs.columbia.edu/~hgs/audio/dvi/IMA_ADPCM.pdf
+
+inline int32_t ima_step_index(int32_t index, int8_t nibble)
+{
+    static int32_t ima_index_table[16] = {
+        -1, -1, -1, -1, 2, 4, 6, 8,
+        -1, -1, -1, -1, 2, 4, 6, 8
+    };
+
+    return std::min(std::max(0, index + ima_index_table[nibble]), 88);
+}
+
+inline int32_t ima_predictor(int32_t predictor, int8_t nibble, int32_t index)
+{
+    static int32_t ima_step_table[89] = {
+        7, 8, 9, 10, 11, 12, 13, 14, 16, 17,
+        19, 21, 23, 25, 28, 31, 34, 37, 41, 45,
+        50, 55, 60, 66, 73, 80, 88, 97, 107, 118,
+        130, 143, 157, 173, 190, 209, 230, 253, 279, 307,
+        337, 371, 408, 449, 494, 544, 598, 658, 724, 796,
+        876, 963, 1060, 1166, 1282, 1411, 1552, 1707, 1878, 2066,
+        2272, 2499, 2749, 3024, 3327, 3660, 4026, 4428, 4871, 5358,
+        5894, 6484, 7132, 7845, 8630, 9493, 10442, 11487, 12635, 13899,
+        15289, 16818, 18500, 20350, 22385, 24623, 27086, 29794, 32767
+    };
+
+    int32_t diff = 0;
+    auto stepsize = ima_step_table[index];
+
+    if (nibble & 4) diff += stepsize;
+    if (nibble & 2) diff += stepsize >> 1;
+    if (nibble & 1) diff += stepsize >> 2;
+    diff += stepsize >> 3;
+    if (nibble & 8) diff = -diff;
+
+    return std::min(std::max(-32768, predictor + diff), 32767);
+}
+
+// MARK: - Constructor
+
+graphite::resources::sound::sound(std::shared_ptr<data::data> data, int64_t id, const std::string name)
+    : m_ref_count(0), m_name(name), m_id(id)
+{
+    // Setup a reader for the snd data, and then parse it.
+    data::reader snd_reader(data);
+    parse(snd_reader);
+}
+
+graphite::resources::sound::sound(uint32_t sample_rate, uint8_t sample_bits, std::vector<std::vector<uint32_t>> sample_data)
+    : m_ref_count(0), m_name("Sound"), m_id(0), m_sample_rate_int(sample_rate), m_sample_rate_frac(0), m_sample_bits(sample_bits), m_sample_data(sample_data)
+{
+
+}
+
+auto graphite::resources::sound::load_resource(int64_t id) -> std::shared_ptr<graphite::resources::sound>
+{
+    if (auto snd_res = graphite::rsrc::manager::shared_manager().find("snd ", id).lock()) {
+        return std::make_shared<resources::sound>(snd_res->data(), id, snd_res->name());
+    }
+    return nullptr;
+}
+
+// MARK: - Accessors
+
+auto graphite::resources::sound::sample_bits() -> uint8_t {
+    return m_sample_bits;
+}
+
+auto graphite::resources::sound::sample_rate() -> uint32_t {
+    return m_sample_rate_int;
+}
+
+auto graphite::resources::sound::samples() -> std::vector<std::vector<uint32_t>> {
+    return m_sample_data;
+}
+
+auto graphite::resources::sound::data() -> std::shared_ptr<graphite::data::data>
+{
+    auto data = std::make_shared<graphite::data::data>();
+    graphite::data::writer writer(data);
+    encode(writer);
+    return data;
+}
+
+// MARK: - Parsing/Reading
+
+auto graphite::resources::sound::parse(graphite::data::reader& snd_reader) -> void
+{
+    // Save the position because our buffer commands reference data by offset from the record start
+    auto reader_pos = snd_reader.position();
+
+    format snd_format = static_cast<format>(snd_reader.read_short());
+
+    uint16_t channel_init_option = 0;
+    if (snd_format == type1) {
+        // We only support sampled sounds; validate the format 1 sound type now
+        auto num_data_formats = snd_reader.read_short();
+        if (num_data_formats != 1) {
+            throw std::runtime_error("Encountered an incompatble snd format: " + std::to_string(num_data_formats) +
+                                     " formats, 1 expected, " + m_name);
+        }
+
+        auto data_format_id = snd_reader.read_short();
+        if (data_format_id != sampledSynth) {
+            throw std::runtime_error("Encountered an incompatble snd format: format " + std::to_string(data_format_id) +
+                                     ", 5 expected, " + m_name);
+        }
+
+        channel_init_option = snd_reader.read_long();
+    }
+    else if (snd_format == type2) {
+        m_ref_count = snd_reader.read_short();
+    }
+    else {
+        throw std::runtime_error("Encountered an incompatble snd format: " + std::to_string(snd_format) + ", " + m_name);
+    }
+
+    // Read command array
+    auto num_commands = snd_reader.read_short();
+    std::vector<command_record> commands;
+    for (auto i = 0; i < num_commands; i++) {
+        auto cmd = snd_reader.read_short();
+        commands.emplace_back(static_cast<command>(cmd & 0x7FFF), snd_reader.read_short(), snd_reader.read_long(), cmd & 0x8000);
+    }
+
+    // We only support sounds with a single buffer command -- validate that now
+    if (commands.size() != 1 || commands[0].cmd != buffer) {
+        throw std::runtime_error("Encountered an incompatble snd format: " + std::to_string(commands.size()) +
+                                " commands, first command " + std::to_string(static_cast<unsigned int>(commands[0].cmd)) +
+                                ", " + m_name);
+    }
+
+    // Move the reader to the buffer command's data offset
+    snd_reader.set_position(reader_pos + commands[0].param2);
+
+    sound_header_record std_header;
+
+    std_header.data_pointer = snd_reader.read_long();
+    std_header.length = snd_reader.read_long();
+    std_header.sample_rate = snd_reader.read_long();
+    std_header.loop_start = snd_reader.read_long();
+    std_header.loop_end = snd_reader.read_long();
+    std_header.sample_encoding = static_cast<sound_encoding>(snd_reader.read_byte());
+    std_header.base_frequency = snd_reader.read_byte();
+
+    m_sample_rate_int = std_header.sample_rate >> 16;
+    m_sample_rate_frac = std_header.sample_rate & 0xFFFF;
+
+    if (std_header.sample_encoding == extSH) {
+        extended_sound_header_record ext_header;
+        ext_header.num_frames = snd_reader.read_long();
+        // skip aiff_sample_rate, marker_chunk, instrument_chunks, aes_recording
+        snd_reader.move(22);
+        ext_header.sample_size = snd_reader.read_short();
+        // skip future_use values
+        snd_reader.move(14);
+
+        m_sample_bits = ext_header.sample_size;
+        // Resize the data vector to fit the channel/frame count
+        m_sample_data.resize(std_header.length, std::vector<uint32_t>(ext_header.num_frames));
+
+        // Raw sound data follows, channels interleaved
+        for (auto f = 0; f < ext_header.num_frames; f++) {
+            for (auto c = 0; c < std_header.length; c++) {
+                m_sample_data[c][f] = ext_header.sample_size == 8 ? snd_reader.read_byte() : snd_reader.read_short();
+            }
+        }
+    }
+    else if (std_header.sample_encoding == cmpSH) {
+        compressed_sound_header_record cmp_header;
+        cmp_header.num_frames = snd_reader.read_long();
+        // skip aiff_sample_rate, marker_chunk
+        snd_reader.move(14);
+        cmp_header.format = snd_reader.read_long();
+        // skip future_use_2, state_vars, leftover_samples
+        snd_reader.move(12);
+        cmp_header.compression_id = static_cast<compression_id>(snd_reader.read_signed_short());
+        cmp_header.packet_size = snd_reader.read_short();
+        // skip snth_id
+        snd_reader.move(2);
+        cmp_header.sample_size = snd_reader.read_short();
+
+        // We only support fixed ima4 compression
+        if (cmp_header.compression_id != fixedCompression || cmp_header.format != 0x696D6134) {
+            throw std::runtime_error("Encountered an incompatble snd format: " + std::to_string(cmp_header.compression_id) +
+                                     " compression ID, format " + std::to_string(cmp_header.format) +
+                                     ", expecting fixed ima4 compression, " + m_name);
+        }
+
+        m_sample_bits = 16;
+         // Resize the data vector to fit the channel count; sample count is frame count * 64
+        m_sample_data.resize(std_header.length, std::vector<uint32_t>(cmp_header.num_frames * 64));
+
+        // Iterate over frames and expand into samples
+        for (auto f = 0; f < cmp_header.num_frames; f++) {
+            for (auto c = 0; c < std_header.length; c++) {
+                // Apple IMA4 parameters described in TN1081:
+                // https://www.fenestrated.net/mirrors/Apple%20Technotes%20(As%20of%202002)/tn/tn1081.html
+                auto preamble = snd_reader.read_short();
+                int32_t predictor = static_cast<int16_t>(preamble & 0xFF80);
+                int32_t step_index = preamble & 0x007F;
+
+                for (auto i = 0; i < 32; i++) {
+                    uint8_t byte = snd_reader.read_byte();
+                    uint8_t lower_nibble = byte & 0x0F;
+                    uint8_t upper_nibble = byte >> 4;
+
+                    predictor = ima_predictor(predictor, lower_nibble, step_index);
+                    step_index = ima_step_index(step_index, lower_nibble);
+                    m_sample_data[c][f * 64 + i * 2] = 32768 + predictor;
+
+                    predictor = ima_predictor(predictor, upper_nibble, step_index);
+                    step_index = ima_step_index(step_index, upper_nibble);
+                    m_sample_data[c][f * 64 + i * 2 + 1] = 32768 + predictor;
+                }
+            }
+        }
+    }
+    else {
+        m_sample_bits = 8;
+        // Resize the data vector to fit the channel/frame count
+        m_sample_data.resize(1, std::vector<uint32_t>(std_header.length));
+
+        // Raw 8-bit mono sound data follows
+        for (auto f = 0; f < std_header.length; f++) {
+            m_sample_data[0][f] = snd_reader.read_byte();
+        }
+    }
+}
+
+// MARK: - Encoder / Writing
+
+auto graphite::resources::sound::encode(graphite::data::writer& snd_writer) -> void
+{
+    // Write the snd header for a format 1 sound
+    snd_writer.write_short(static_cast<uint16_t>(type1));
+    snd_writer.write_short(1); // num_data_formats
+    snd_writer.write_short(static_cast<uint16_t>(sampledSynth)); // first_data_format_id
+    snd_writer.write_long(static_cast<uint16_t>(initMono)); // channel_init_option
+    snd_writer.write_short(1); // num_commands
+    snd_writer.write_short(0x8000 | static_cast<uint16_t>(buffer)); // command: cmd, high bit set to indicate offset
+    snd_writer.write_short(0); // command: param1
+    snd_writer.write_long(20); // command: param2, offset from start of record to sound data
+
+    auto num_samples = m_sample_data.size() ? m_sample_data[0].size() : 0;
+
+    // Write the standard sampled sound header fields
+    snd_writer.write_long(0); // data pointer
+    snd_writer.write_long(num_samples); // number of samples
+    snd_writer.write_long(m_sample_rate_int << 16 | m_sample_rate_frac); // sample rate (fixed-point)
+    snd_writer.write_long(0); // loop start
+    snd_writer.write_long(0); // loop end
+    snd_writer.write_byte(static_cast<uint8_t>(stdSH)); // encoding option
+    snd_writer.write_byte(0); // base frequency
+
+    // Truncate and write the sound data as 8-bit mono
+    for (auto f = 0; f < num_samples; f++) {
+        snd_writer.write_byte(m_sample_data[0][f] >> (m_sample_bits - 8));
+    }
+}
+
+// MARK: - Sound record construction
+
+graphite::resources::sound::command_record::command_record(const command cmd, const uint16_t param1,
+                                                           const uint32_t param2, const bool data_offset_flag)
+    : cmd(cmd), param1(param1), param2(param2), data_offset_flag(data_offset_flag)
+{
+
+}

--- a/libGraphite/resources/sound.hpp
+++ b/libGraphite/resources/sound.hpp
@@ -1,0 +1,176 @@
+//
+// Created by Tom Hancocks on 24/03/2020.
+//
+
+#if !defined(GRAPHITE_SOUND_HPP)
+#define GRAPHITE_SOUND_HPP
+
+#include <memory>
+#include <string>
+#include <vector>
+#include "libGraphite/data/data.hpp"
+#include "libGraphite/data/reader.hpp"
+#include "libGraphite/data/writer.hpp"
+
+namespace graphite { namespace resources {
+
+    class sound
+    {
+    private:
+        enum format : uint16_t { type1 = 0x0001, type2 = 0x0002 };
+
+        enum command : uint16_t
+        {
+            null = 0,                   // Do nothing
+            quiet = 3,                  // Stop a sound that is playing
+            flush = 4,                  // Flush a sound channel
+            reinit = 5,                 // Reinitialise a sound channel
+            wait = 10,                  // Suspend processing in a channel
+            pause = 11,                 // Pause processing in a channel
+            resume = 12,                // Resume processing in a channel
+            callback = 13,              // Execute a callback procedure
+            sync = 14,                  // Synchronise channels
+            available = 24,             // See if initialisation options are supported.
+            version = 25,               // Determine version
+            totalLoad = 26,             // Report total cpu load
+            load = 27,                  // Report cpu load for a new channel
+            freqDuration = 40,          // Play a note for a duration
+            rest = 41,                  // Rest a channel for a duration
+            freq = 42,                  // Change pitch of a sound
+            amp = 43,                   // Change the amplitude of a sound
+            timbre = 44,                // Change the timbre of a sound
+            getAmp = 45,                // Get the amplitude of a sound
+            volume = 46,                // Set the volume
+            getVolume = 47,             // Get the volume
+            waveTable = 60,             // Install a wave table as a voice
+            play_sound = 80,            // Install a sampled sound as a voice
+            buffer = 81,                // Play a sampled sound
+            rate = 82,                  // Set the pitch of a sampled sound
+            getRate = 83,               // Get the pitch of a sampled sound
+        };
+
+        enum data_format : uint16_t {
+            squareWaveSynth = 1,        // Square-wave data
+            waveTableSynth = 3,         // Wave-table data
+            sampledSynth = 5,           // Sampled-sound data
+        };
+
+        enum channel_init_option : uint32_t {
+            initChanLeft = 0x0002,      // Left stereo channel
+            initChanRight = 0x0003,     // Right stereo channel
+            waveInitChannel0 = 0x0004,  // Wave-table channel 0
+            waveInitChannel1 = 0x0005,  // Wave-table channel 1
+            waveInitChannel2 = 0x0006,  // Wave-table channel 2
+            waveInitChannel3 = 0x0007,  // Wave-table channel 3
+            initMono = 0x0080,          // Monophonic channel
+            initStereo = 0x00C0,        // Stereo channel
+            initMACE3 = 0x0300,         // 3:1 compression
+            initMACE6 = 0x0400,         // 6:1 compression
+            initNoInterp = 0x0004,      // No linear interpolation
+            initNoDrop = 0x0008,        // No drop-sample conversion
+        };
+
+        enum sound_encoding : uint8_t {
+            stdSH = 0x00,               // Standard sound header
+            extSH = 0xFF,               // Extended sound header
+            cmpSH = 0xFE,               // Compressed sound header
+        };
+
+        enum compression_id : int16_t {
+            variableCompression = -2,   // Variable-ratio compression
+            fixedCompression = -1,      // Fixed-ratio compression
+            notCompressed = 0,          // Non-compressed samples
+            threeToOne = 3,             // 3:1 compressed samples
+            sixToOne = 6,               // 6:1 compressed samples
+        };
+
+        struct command_record
+        {
+        public:
+            enum command cmd;
+            uint16_t param1;
+            uint32_t param2;
+            bool data_offset_flag;
+
+            command_record(const command cmd, const uint16_t param1, const uint32_t param2, const bool data_offset_flag);
+        };
+
+        struct sound_header_record
+        {
+        public:
+            uint32_t data_pointer;      // If nil, samples follow header
+            uint32_t length;            // Number of samples in array
+            uint32_t sample_rate;       // Sample rate (Fixed)
+            uint32_t loop_start;        // Loop start point sample byte number
+            uint32_t loop_end;          // Loop end point sample byte number
+            enum sound_encoding sample_encoding; // Sample encoding option
+            uint8_t base_frequency;     // Base frequency of sample
+        };
+
+        struct extended_sound_header_record
+        {
+        public:
+            // The length field in standard_header is interpreted as num_channels
+            uint32_t num_frames;        // The number of frames in the sampled-sound data.
+                                        // Each frame contains num_channels bytes for 8-bit sound data.
+            uint8_t aiff_sample_rate[10]; // The sample rate at which the frames were sampled before compression,
+                                          // as expressed in the 80-bit extended data type representation
+            uint32_t marker_chunk;      // Pointer to synchronization information. Unused, set to NIL.
+            uint32_t instrument_chunks; // Pointer to instrument information.
+            uint32_t aes_recording;     // Pointer to information related to audio recording devices.
+            uint16_t sample_size;       // The number of bits in each sample frame.
+            uint16_t future_use_1;      // Reserved
+            uint32_t future_use_2;      // Reserved
+            uint32_t future_use_3;      // Reserved
+            uint32_t future_use_4;      // Reserved
+        };
+
+        struct compressed_sound_header_record
+        {
+        public:
+            // The length field in standard_header is interpreted as num_channels
+            uint32_t num_frames;        // The number of frames in the sampled-sound data.
+                                        // Each frame contains num_channels bytes for 8-bit sound data.
+            uint8_t aiff_sample_rate[10]; // The sample rate at which the frames were sampled before compression,
+                                          // as expressed in the 80-bit extended data type representation
+            uint32_t marker_chunk;      // Pointer to synchronization information. Unused, set to NIL.
+            uint32_t format;            // OSType, e.g. 'MAC3' for MACE3:1
+            uint32_t future_use_2;      // Reserved
+            uint32_t state_vars;        // Pointer to StateBlock
+            uint32_t leftover_samples;  // Pointer to LeftOverBlock
+            enum compression_id compression_id; // The compression algorithm used on the samples in the compressed sound header.
+            uint16_t packet_size;       // The size, in bits, of the smallest element that a given expansion algorithm can work with.
+            uint16_t snth_id;           // This field is unused. You should set it to 0.
+            uint16_t sample_size;       // The size of the sample before it was compressed.
+        };
+
+        // Basic resource information
+        int16_t m_id;
+        std::string m_name;
+
+        // Sound information
+        uint16_t m_ref_count;
+        uint32_t m_sample_rate_int;
+        uint16_t m_sample_rate_frac;
+        uint8_t m_sample_bits;
+        std::vector<std::vector<uint32_t>> m_sample_data;
+
+        auto parse(graphite::data::reader& snd_reader) -> void;
+        auto encode(graphite::data::writer& snd_writer) -> void;
+
+    public:
+        sound(std::shared_ptr<graphite::data::data> data, int64_t id = 0, std::string name = "");
+        sound(uint32_t sample_rate, uint8_t sample_bits, std::vector<std::vector<uint32_t>> sample_data);
+
+        static auto load_resource(int64_t id) -> std::shared_ptr<sound>;
+
+        auto sample_bits() -> uint8_t;
+        auto sample_rate() -> uint32_t;
+        auto samples() -> std::vector<std::vector<uint32_t>>;
+
+        auto data() -> std::shared_ptr<graphite::data::data>;
+    };
+
+}};
+
+#endif


### PR DESCRIPTION
Supports `snd ` resources with the options outlined below.

Reading:

* Formats 1 and 2
* Standard, extended or compressed sampled sound data
* 8, 16, 24 or 32 bits per sample (note EV only uses 8 and 16)
* IMA4 compression
* Stereo/multichannel samples (note EV only uses mono)

Writing:

* Format 1
* Standard sampled sound data
* 8 bits per sample
* Mono

Internally, sounds are represented as an array of channels, each of which contains an array of unsigned 32-bit samples. The loaded data is stored in the least significant bytes of the sample, with the sample bit depth indicating the actual size used.

When writing samples of greater than 8 bits, no dithering is performed—only the 8 most significant bits of the sample are written.