### PR TITLE
Add graphite::rsrc::file::types()

### DIFF
--- a/libGraphite/rsrc/file.cpp
+++ b/libGraphite/rsrc/file.cpp
@@ -39,6 +39,11 @@ auto graphite::rsrc::file::type_count() const -> std::size_t
 	return m_types.size();
 }
 
+auto graphite::rsrc::file::types() const -> std::vector<std::shared_ptr<type>>
+{
+    return m_types;
+}
+
 auto graphite::rsrc::file::current_format() const -> graphite::rsrc::file::format
 {
 	return m_format;

--- a/libGraphite/rsrc/file.hpp
+++ b/libGraphite/rsrc/file.hpp
@@ -95,6 +95,11 @@ namespace graphite { namespace rsrc {
          * Returns the number of types contained in the resource file.
          */
         auto type_count() const -> std::size_t;
+        
+        /**
+         * Returns the list of all types contained in the resource file.
+         */
+        auto types() const -> std::vector<std::shared_ptr<type>>;
 
         /**
          * Reports the current format of the resource file.


### PR DESCRIPTION
This PR add an accessor for the types vector on graphite::rsrc::file, to allow enumerating the types.