### PR TITLE
Handle empty resources

### DIFF
--- a/libGraphite/data/data.cpp
+++ b/libGraphite/data/data.cpp
@@ -58,7 +58,7 @@ auto graphite::data::data::size() const -> std::size_t
     if (m_size > 0) {
         return m_size;
     }
-    else if (m_data != nullptr) {
+    else if (m_data != nullptr && m_start == 0) {
         return m_data->size();
     }
     else {


### PR DESCRIPTION
This PR changes the `graphite::data::data::size()` function to only return the full size of the data if both `m_size` and `m_start` are zero. This allows it to correctly handle empty resources. Fixes #5.

(I'm not sure what the need is to have it return the full size of the data like that but it should still work for that purpose).