### PR TITLE
Fixes for reading extended format

### DIFF
--- a/libGraphite/data/reader.cpp
+++ b/libGraphite/data/reader.cpp
@@ -152,7 +152,7 @@ auto graphite::data::reader::read_integer(int64_t offset, graphite::data::reader
     
     for (auto i = 0; i < size; ++i) {
         auto b = static_cast<uint8_t>(m_data->at(m_pos + offset + i));
-        v |= b << (i << 3);
+        v |= static_cast<T>(b) << (i << 3);
     }
     
     if (size > 1) {

--- a/libGraphite/rsrc/extended.cpp
+++ b/libGraphite/rsrc/extended.cpp
@@ -49,19 +49,19 @@ auto graphite::rsrc::extended::parse(std::shared_ptr<graphite::data::reader> rea
 	// Now move to the start of the resource map, and verify the contents of the preamble.
 	reader->set_position(map_offset);
 
-	if (reader->read_long() != data_offset) {
+	if (reader->read_quad() != data_offset) {
 		throw std::runtime_error("[Extended Resource File] Second Preamble 'data_offset' mismatch.");
 	}
 
-	if (reader->read_long() != map_offset) {
+	if (reader->read_quad() != map_offset) {
 		throw std::runtime_error("[Extended Resource File] Second Preamble 'map_offset' mismatch.");
 	}
 
-	if (reader->read_long() != data_length) {
+	if (reader->read_quad() != data_length) {
 		throw std::runtime_error("[Extended Resource File] Second Preamble 'data_length' mismatch.");
 	}
 
-	if (reader->read_long() != map_length) {
+	if (reader->read_quad() != map_length) {
 		throw std::runtime_error("[Extended Resource File] Second Preamble 'map_length' mismatch.");
 	}
 


### PR DESCRIPTION
This PR fixes two issues with reading the extended format.

1. There was a problem reading 64-bit values (at least on my system) where the bitshifting seemed to be restricted to 32-bit values. I've resolved this with a `static_cast<T>`. (Not sure if this is the best way to fix it)
2. Reading of the second preamble was using read_longs instead of read_quads.