### PR TITLE
Add support for ppat resource

### DIFF
--- a/libGraphite/quickdraw/pixmap.cpp
+++ b/libGraphite/quickdraw/pixmap.cpp
@@ -143,6 +143,16 @@ auto graphite::qd::pixmap::pixel_format() const -> enum graphite::qd::pixel_form
     return m_pixel_format;
 }
 
+auto graphite::qd::pixmap::pm_table() const -> uint32_t
+{
+    return m_pm_table;
+}
+
+auto graphite::qd::pixmap::set_pm_table(const uint32_t pm_table) -> void
+{
+    m_pm_table = pm_table;
+}
+
 // MARK: -
 
 auto graphite::qd::pixmap::write(graphite::data::writer& writer) -> void

--- a/libGraphite/quickdraw/pixmap.cpp
+++ b/libGraphite/quickdraw/pixmap.cpp
@@ -155,6 +155,45 @@ auto graphite::qd::pixmap::set_pm_table(const uint32_t pm_table) -> void
 
 // MARK: -
 
+auto graphite::qd::pixmap::build_pixel_data(std::vector<uint16_t> color_values, uint16_t pixel_size) -> std::shared_ptr<graphite::data::data>
+{
+    graphite::data::writer pmap_data(std::make_shared<graphite::data::data>());
+    m_pixel_size = m_cmp_size = pixel_size;
+    m_cmp_count = 1;
+
+    if (pixel_size == 8) {
+        m_row_bytes = m_bounds.width();
+        for (auto n = 0; n < color_values.size(); ++n) {
+            pmap_data.write_byte(static_cast<uint8_t>(color_values[n] & 0xFF));
+        }
+    }
+    else {
+        auto width = m_bounds.width();
+        auto mod = 8 / pixel_size;
+        m_row_bytes = (width - 1) / mod + 1;
+        auto mask = (1 << pixel_size) - 1;
+        auto diff = 8 - pixel_size;
+
+        for (auto y = 0; y < m_bounds.height(); ++y) {
+            uint8_t scratch = 0;
+            for (auto x = 0; x < width; ++x) {
+                auto bit_offset = x % mod;
+                if (bit_offset == 0 && x != 0) {
+                    pmap_data.write_byte(scratch);
+                    scratch = 0;
+                }
+                auto n = y * width + x;
+                uint8_t value = static_cast<uint8_t>(color_values[n] & mask);
+                value <<= (diff - (bit_offset * pixel_size));
+                scratch |= value;
+            }
+            pmap_data.write_byte(scratch);
+        }
+    }
+
+    return pmap_data.data();
+}
+
 auto graphite::qd::pixmap::write(graphite::data::writer& writer) -> void
 {
     writer.write_long(m_base_address);

--- a/libGraphite/quickdraw/pixmap.hpp
+++ b/libGraphite/quickdraw/pixmap.hpp
@@ -70,6 +70,7 @@ namespace graphite { namespace qd {
         auto set_cmp_size(const int16_t cmp_size) -> void;
         auto set_pm_table(const uint32_t pm_table) -> void;
 
+        auto build_pixel_data(std::vector<uint16_t> color_values, uint16_t pixel_size) -> std::shared_ptr<graphite::data::data>;
         auto write(graphite::data::writer& writer) -> void;
     };
 

--- a/libGraphite/quickdraw/pixmap.hpp
+++ b/libGraphite/quickdraw/pixmap.hpp
@@ -58,6 +58,7 @@ namespace graphite { namespace qd {
         auto cmp_count() const -> int16_t;
         auto cmp_size() const -> int16_t;
         auto pixel_format() const -> enum pixel_format;
+        auto pm_table() const -> uint32_t;
 
         auto set_bounds(const graphite::qd::rect rect) -> void;
         auto set_row_bytes(const int16_t row_bytes) -> void;
@@ -67,6 +68,7 @@ namespace graphite { namespace qd {
         auto set_pixel_size(const int16_t pixel_size) -> void;
         auto set_cmp_count(const int16_t cmp_count) -> void;
         auto set_cmp_size(const int16_t cmp_size) -> void;
+        auto set_pm_table(const uint32_t pm_table) -> void;
 
         auto write(graphite::data::writer& writer) -> void;
     };

--- a/libGraphite/quickdraw/ppat.hpp
+++ b/libGraphite/quickdraw/ppat.hpp
@@ -1,0 +1,42 @@
+//
+// Created by Tom Hancocks on 17/07/2020.
+//
+
+#if !defined(GRAPHITE_PPAT_HPP)
+#define GRAPHITE_PPAT_HPP
+
+#include <string>
+#include "libGraphite/quickdraw/internal/surface.hpp"
+#include "libGraphite/quickdraw/geometry.hpp"
+#include "libGraphite/quickdraw/pixmap.hpp"
+#include "libGraphite/quickdraw/clut.hpp"
+
+namespace graphite { namespace qd {
+
+    class ppat
+    {
+    private:
+        int64_t m_id;
+        std::string m_name;
+        uint16_t m_pat_type;
+        uint32_t m_pmap_base_addr;
+        uint32_t m_pat_base_addr;
+        qd::pixmap m_pixmap;
+        std::shared_ptr<qd::surface> m_surface;
+        qd::clut m_clut;
+
+        auto parse(data::reader& reader) -> void;
+
+    public:
+        ppat(std::shared_ptr<graphite::data::data> data, int64_t id = 0, std::string name = "");
+        ppat(std::shared_ptr<qd::surface> surface);
+
+        static auto load_resource(int64_t id) -> std::shared_ptr<ppat>;
+
+        auto surface() const -> std::weak_ptr<graphite::qd::surface>;
+        auto data() -> std::shared_ptr<graphite::data::data>;
+    };
+
+}};
+
+#endif //GRAPHITE_PPAT_HPP


### PR DESCRIPTION
This PR adds support for the Pixel Pattern 'ppat' resource, used by EV Nova for radar interference patterns.
The ppat class is mostly just a copy of the cicn class with masks removed. It also modifies the pixmap class to allow getting/setting the pm_table.

I'll look into adding ppat support to kdl as well...