### PR TITLE
Throw error if quicktime data

### DIFF
--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -385,6 +385,10 @@ auto graphite::qd::pict::parse(graphite::data::reader& pict_reader) -> void
             case opcode::def_hilite: {
                 break;
             }
+            case opcode::compressed_quicktime:
+            case opcode::uncompressed_quicktime: {
+                throw std::runtime_error("Encountered an incompatible PICT: " + std::to_string(m_id) + ", " + m_name);
+            }
         }
     }
 }

--- a/libGraphite/quickdraw/pict.hpp
+++ b/libGraphite/quickdraw/pict.hpp
@@ -28,6 +28,8 @@ namespace graphite { namespace qd {
             def_hilite = 0x001e,
             long_comment = 0x00a1,
             ext_header = 0x0c00,
+            compressed_quicktime = 0x8200,
+            uncompressed_quicktime = 0x8201,
         };
 
     private:


### PR DESCRIPTION
This PR adds an error check if QuickTime data is encountered while parsing a PICT.

For reference, attached is an EV Nova plug-in that contains QuickTime compressed PICTs.
[rEV_Yards.zip](https://github.com/TheDiamondProject/Graphite/files/4985938/rEV_Yards.zip)
