### PR TITLE
Fixes for pict decoding

### DIFF
--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -148,6 +148,8 @@ auto graphite::qd::pict::read_pack_bits_rect(graphite::data::reader & pict_reade
 
             auto packed_data = read_bytes(pict_reader, packed_bytes_count);
             qd::packbits::decode(raw, packed_data, sizeof(uint8_t));
+            // Decoded packbits may contain more data than the row requires - trim it to width
+            raw.resize(source_rect.width());
         }
         else {
             raw = read_bytes(pict_reader, row_bytes);

--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -280,7 +280,7 @@ auto graphite::qd::pict::read_direct_bits_rect(graphite::data::reader &pict_read
                 for (uint32_t x = 0; x < width; x++) {
                     px_long_buffer[px_buffer_offset + x] =
                             ((raw[x] & 0xFF) << 24)
-                            | ((raw[bounds_width] & 0xFF) << 16)
+                            | ((raw[bounds_width + x] & 0xFF) << 16)
                             | ((raw[2 * bounds_width + x] & 0xFF) << 8)
                             | (raw[3 * bounds_width + x] & 0xFF);
                 }


### PR DESCRIPTION
This PR makes two fixes for pict decoding:
1. Decoding packbits could produce more data than required, e.g. for odd width images. The data will now be trimmed to the correct length.
2. Red channel for ARGB data was not set correctly.

I've attached a test file here. Note two of the picts are in ARGB format and the alpha shows they are mostly transparent. Most other software (including ResEdit) seem to ignore the alpha though. Wondering if we should be doing so too?

[pict test.rsrc.zip](https://github.com/TheDiamondProject/Graphite/files/5140062/pict.test.rsrc.zip)

