### PR TITLE
Support indexed color tables

### DIFF
--- a/libGraphite/quickdraw/clut.cpp
+++ b/libGraphite/quickdraw/clut.cpp
@@ -47,6 +47,9 @@ auto graphite::qd::clut::at(int index) const -> graphite::qd::color
 
 auto graphite::qd::clut::get(int value) const -> graphite::qd::color
 {
+    if (m_flags == device) {
+        return at(value);
+    }
     for (auto entry : m_entries) {
         if (std::get<0>(entry) == value) {
             return std::get<1>(entry);


### PR DESCRIPTION
This PR fixes an issue reading PICTs with indexed color tables. It changes the `clut::get` method to defer to `clut::at` if the indexed device flag is set.