### PR TITLE
Extended Resource Attributes

### DIFF
--- a/GraphiteTest/main.cpp
+++ b/GraphiteTest/main.cpp
@@ -20,16 +20,31 @@
 
 #include "libGraphite/rsrc/file.hpp"
 #include "libGraphite/data/writer.hpp"
+#include <iostream>
 
 int main(int argc, char const *argv[])
 {
     auto rf = std::make_shared<graphite::rsrc::file>();
     
-    auto writer = std::make_shared<graphite::data::writer>();
-    writer->write_cstr("Hello, World!");
-    rf->add_resource("test", 128, "test resource", writer->data());
+    auto english = std::make_shared<graphite::data::writer>();
+    english->write_cstr("Hello, World!");
+    rf->add_resource("test", 128, "test resource", english->data(), {
+        std::make_pair("lang", "en")
+    });
+
+    auto french = std::make_shared<graphite::data::writer>();
+    french->write_cstr("Bonjour, Monde!");
+    rf->add_resource("test", 128, "test resource", french->data(), {
+        std::make_pair("lang", "fr")
+    });
 
     // The resource file should be assembled at this point and just needs writting to disk.
-    rf->write("/Users/tomhancocks/Desktop/out.ndat", graphite::rsrc::file::format::classic);
+    rf->write("/tmp/localised.rsrc", graphite::rsrc::file::format::extended);
+
+
+    auto in_rf = std::make_shared<graphite::rsrc::file>("/tmp/localised.rsrc");
+    for (const auto& type : in_rf->types()) {
+        std::cout << "reading type: " << type->code() << type->attributes_string() << std::endl;
+    }
 	return 0;
 }

--- a/libGraphite/rsrc/extended.cpp
+++ b/libGraphite/rsrc/extended.cpp
@@ -18,7 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <iostream>
 #include <limits>
 #include "libGraphite/rsrc/extended.hpp"
 #include "libGraphite/encoding/macroman/macroman.hpp"
@@ -226,8 +225,6 @@ auto graphite::rsrc::extended::write(const std::string& path, std::vector<std::s
         writer->write_quad(type->count() - 1);
         writer->write_quad(resource_offset);
         writer->write_quad(attribute_offset);
-
-        std::cout << "adding type: " << type->code() << type->attributes_string() << std::endl;
 
         for (const auto& attribute : type->attributes()) {
             attribute_offset += sizeof(uint64_t) + attribute.first.size() + attribute.second.size() + 2;

--- a/libGraphite/rsrc/file.hpp
+++ b/libGraphite/rsrc/file.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <map>
 #include "libGraphite/data/data.hpp"
 #include "libGraphite/rsrc/type.hpp"
 
@@ -72,7 +73,7 @@ namespace graphite { namespace rsrc {
          * Construct a new `graphite::rsrc::file` by loading the contents of the specified
          * file.
          */
-        file(const std::string& path);
+        explicit file(const std::string& path);
 
         /**
          * Read and parse the contents of the resource file at the specified location.
@@ -109,18 +110,23 @@ namespace graphite { namespace rsrc {
         /**
          * Add a resource into the receiver.
          */
-        auto add_resource(const std::string& type, int64_t id, const std::string& name, std::shared_ptr<graphite::data::data> data) -> void;
+        auto add_resource(const std::string& type,
+                          const int64_t& id,
+                          const std::string& name,
+                          const std::shared_ptr<graphite::data::data>& data,
+                          const std::map<std::string, std::string>& attributes = {}) -> void;
 
         /**
          * Retrieve a type container for the specified type code. If a container
          * does not exist then create one.
          */
-        auto type_container(const std::string& code) -> std::weak_ptr<graphite::rsrc::type>;
+        auto type_container(const std::string& code,
+                            const std::map<std::string, std::string>& attributes = {}) -> std::weak_ptr<graphite::rsrc::type>;
 
         /**
          * Attempt to get the resource of the specified type and id.
          */
-        auto find(const std::string& type, const int64_t& id) -> std::weak_ptr<resource>;
+        auto find(const std::string& type, const int64_t& id, const std::map<std::string, std::string> &attributes) -> std::weak_ptr<resource>;
     };
 
 }}

--- a/libGraphite/rsrc/manager.cpp
+++ b/libGraphite/rsrc/manager.cpp
@@ -49,10 +49,10 @@ auto graphite::rsrc::manager::files() const -> std::vector<std::shared_ptr<file>
 
 // MARK: - Resource Look Up
 
-auto graphite::rsrc::manager::find(const std::string& type, const int64_t& id) const -> std::weak_ptr<graphite::rsrc::resource>
+auto graphite::rsrc::manager::find(const std::string& type, const int64_t& id, const std::map<std::string, std::string>& attributes) const -> std::weak_ptr<graphite::rsrc::resource>
 {
     for (auto i = m_files.rbegin(); i != m_files.rend(); ++i) {
-        auto res = (*i)->find(type, id);
+        auto res = (*i)->find(type, id, attributes);
         if (!res.expired()) {
             return res;
         }
@@ -60,11 +60,11 @@ auto graphite::rsrc::manager::find(const std::string& type, const int64_t& id) c
     return std::weak_ptr<graphite::rsrc::resource>();
 }
 
-auto graphite::rsrc::manager::get_type(const std::string &type) const -> std::vector<std::weak_ptr<rsrc::type>>
+auto graphite::rsrc::manager::get_type(const std::string &type, const std::map<std::string, std::string>& attributes) const -> std::vector<std::weak_ptr<rsrc::type>>
 {
     std::vector<std::weak_ptr<rsrc::type>> v;
     for (auto i = m_files.rbegin(); i != m_files.rend(); ++i) {
-        v.emplace_back((*i)->type_container(type));
+        v.emplace_back((*i)->type_container(type, attributes));
     }
     return v;
 }

--- a/libGraphite/rsrc/manager.hpp
+++ b/libGraphite/rsrc/manager.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <map>
 #include "libGraphite/rsrc/file.hpp"
 
 #if !defined(GRAPHITE_RSRC_MANAGER)
@@ -70,12 +71,12 @@ namespace graphite { namespace rsrc {
         /**
          * Attempt to get the resource of the specified type and id.
          */
-        auto find(const std::string& type, const int64_t& id) const -> std::weak_ptr<resource>;
+        auto find(const std::string& type, const int64_t& id, const std::map<std::string, std::string>& attributes = {}) const -> std::weak_ptr<resource>;
 
         /**
          * Returns a list of type containers for the specified type code.
          */
-        auto get_type(const std::string& type) const -> std::vector<std::weak_ptr<rsrc::type>>;
+        auto get_type(const std::string& type, const std::map<std::string, std::string>& attributes = {}) const -> std::vector<std::weak_ptr<rsrc::type>>;
     };
 
 }}

--- a/libGraphite/rsrc/type.cpp
+++ b/libGraphite/rsrc/type.cpp
@@ -20,39 +20,57 @@
 
 #include "libGraphite/rsrc/type.hpp"
 
+#include <utility>
+
 // MARK: - Constructor
 
-graphite::rsrc::type::type(const std::string& code)
-	: m_code(code)
+graphite::rsrc::type::type(std::string  code, std::map<std::string, std::string>  attributes)
+	: m_code(std::move(code)), m_attributes(std::move(attributes))
 {
 	
 }
 
 // MARK: - Metadata Accessors
 
-std::string graphite::rsrc::type::code() const
+auto graphite::rsrc::type::code() const -> std::string
 {
 	return m_code;
 }
 
+auto graphite::rsrc::type::attributes() const -> std::map<std::string, std::string>
+{
+    return m_attributes;
+}
+
+auto graphite::rsrc::type::attributes_string() const -> std::string
+{
+    std::string text;
+
+    for (const auto& m_attribute : m_attributes) {
+        text.append(":" + m_attribute.first + "=" + (m_attribute.second));
+    }
+
+    return text;
+}
+
 // MARK: - Resource Management
 
-std::size_t graphite::rsrc::type::count() const
+auto graphite::rsrc::type::count() const -> std::size_t
 {
 	return m_resources.size();
 }
 
-void graphite::rsrc::type::add_resource(std::shared_ptr<graphite::rsrc::resource> resource)
+auto graphite::rsrc::type::add_resource(std::shared_ptr<graphite::rsrc::resource> resource) -> void
 {
 	m_resources.push_back(resource);
 }
 
-std::vector<std::shared_ptr<graphite::rsrc::resource>> graphite::rsrc::type::resources() const
+auto graphite::rsrc::type::resources() const -> std::vector<std::shared_ptr<graphite::rsrc::resource>>
 {
 	return m_resources;
 }
 
-std::weak_ptr<graphite::rsrc::resource> graphite::rsrc::type::get(int16_t id) const
+auto graphite::rsrc::type::get(int16_t id) const -> std::weak_ptr<graphite::rsrc::resource>
 {
     for (auto r = m_resources.begin(); r != m_resources.end(); ++r) {
         if ((*r)->id() == id) {

--- a/libGraphite/rsrc/type.hpp
+++ b/libGraphite/rsrc/type.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <map>
 #include "libGraphite/rsrc/resource.hpp"
 
 #if !defined(GRAPHITE_RSRC_TYPE)
@@ -36,18 +37,29 @@ namespace graphite { namespace rsrc {
     private:
         std::string m_code;
         std::vector<std::shared_ptr<resource>> m_resources;
+        std::map<std::string, std::string> m_attributes;
 
     public:
     	/**
     	 * Construct a new a resource type container with the specified
     	 * type code.
     	 */
-    	type(const std::string& code);
+    	explicit type(std::string  code, std::map<std::string, std::string>  attributes = {});
 
     	/**
     	 * Returns the type code of the receiver.
     	 */
     	auto code() const -> std::string;
+
+    	/**
+    	 * Returns the attribute map of the receiver.
+    	 */
+    	 auto attributes() const -> std::map<std::string, std::string>;
+
+    	/**
+    	 * Returns the attribute map of the receiver as a string.
+    	 */
+    	 auto attributes_string() const -> std::string;
 
     	/**
     	 * Returns a count of the number of resources associated to this type.


### PR DESCRIPTION
The idea of this to add a attribute mechanism to the type containers of extended resource forks, thus allowing multiple occurrences of the same "type" but distinct from each other.

For example:

```
+ 'dësc'
    - #128: Test Resource
    - #129: Something else
+ 'dësc' [lang=fr]
    - #128: Test Resource (French)
+ 'dësc' [lang=de]
    - #128: Test Resource (German)
```