### PR TITLE
PICT decoding fixes

### DIFF
--- a/libGraphite/quickdraw/geometry.cpp
+++ b/libGraphite/quickdraw/geometry.cpp
@@ -329,7 +329,7 @@ auto graphite::qd::rect::read(graphite::data::reader& reader, enum coding_type t
         case coding_type::qd: {
             auto origin = qd::point::read(reader, point::qd);
             auto opposite = qd::point::read(reader, point::qd);
-            return qd::rect(origin, qd::size(origin.x() + opposite.x(), origin.y() + opposite.y()));
+            return qd::rect(origin, qd::size(opposite.x() - origin.x(), opposite.y() - origin.y()));
         }
         case coding_type::pict: {
             auto origin = point::read(reader, point::pict);

--- a/libGraphite/quickdraw/internal/packbits.cpp
+++ b/libGraphite/quickdraw/internal/packbits.cpp
@@ -12,6 +12,9 @@ auto graphite::qd::packbits::decode(std::vector<uint8_t> &out_data, const std::v
         auto count = pack_data[pos++];
         if (count >= 0 && count < 128) {
             uint16_t run = (1 + count) * value_size;
+            if ((pos + run) > pack_data.size()) {
+                throw std::runtime_error("Unable to decode packbits.");
+            }
             out_data.insert(out_data.end(), std::make_move_iterator(pack_data.begin() + pos), std::make_move_iterator(pack_data.begin() + pos + run));
             pos += run;
         }


### PR DESCRIPTION
This PR makes PICT decoding a little safer by ensuring buffers are allocated with the appropriate size and throwing an exception when the packbits data is invalid.

Fixes crashes caused by PICTs mentioned in #21, though doesn't (yet) decode them successfully.