### PR TITLE
Performance improvements

### DIFF
--- a/libGraphite/quickdraw/internal/packbits.cpp
+++ b/libGraphite/quickdraw/internal/packbits.cpp
@@ -18,7 +18,9 @@ auto graphite::qd::packbits::decode(std::vector<uint8_t> &out_data, const std::v
         else if (count >= 128) {
             uint8_t run = 256 - count + 1;
             for (uint8_t i = 0; i < run; ++i) {
-                out_data.insert(out_data.end(), std::make_move_iterator(pack_data.begin() + pos), std::make_move_iterator(pack_data.begin() + pos + value_size));
+                for (uint8_t j = 0; j < value_size; ++j) {
+                    out_data.push_back(pack_data[pos + j]);
+                }
             }
             pos += value_size;
         }


### PR DESCRIPTION
This PR makes a couple of changes to improve performance:
1. Changes packbits runs to a double loop with `push_back` instead of `insert`.
2. Changes clut reader to index the entries by their value when the device flag is not set. This allows instant lookups via `get` rather than having to search for the value. Note this ensures safe values by modding them by the count, which in theory could give incorrect results in some cases, but ImagickMagick appears to be doing it the same way (as best I can tell) so I figure it's okay.

(This is primarily helpful for me when running debug builds, which can be pretty slow at decoding PICTs. 1. may not actually make any difference in production.)