### PR TITLE
linux and gcc compatibility

### DIFF
--- a/libGraphite/data/data.hpp
+++ b/libGraphite/data/data.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 #include <string>
 #include <type_traits>
+#include <stdexcept>
 
 namespace graphite::data {
 

--- a/libGraphite/quickdraw/internal/packbits.hpp
+++ b/libGraphite/quickdraw/internal/packbits.hpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <memory>
+#include <stdexcept>
 
 namespace graphite::qd {
 


### PR DESCRIPTION
Here are a few spots where gcc seems to complain. Version 9.3.0 didn't have any problems for me, but version 10.2.0 had these two.