### PR TITLE
Add GitHub Actions builds for Linux and macOS

### DIFF
--- a/.github/actions/build_linux/Dockerfile
+++ b/.github/actions/build_linux/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:bullseye-20210208-slim
+
+RUN apt-get update -y -q && \
+  apt-get install -y -q --no-install-recommends build-essential \
+  gcc \
+  cmake && \
+  apt-get clean
+
+ENTRYPOINT ["/github/workspace/.github/actions/build_linux/entrypoint.sh"]

--- a/.github/actions/build_linux/entrypoint.sh
+++ b/.github/actions/build_linux/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -l
+
+cmake -H. -Bbuild
+cmake --build build -- -j2

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,12 @@
+on: [push]
+
+jobs:
+  build:
+    name: Build on Linux
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run build
+        uses: ./.github/actions/build_linux

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,17 @@
+on: [push]
+
+jobs:
+  build:
+    name: Build on macOS
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install depdendencies
+        run: brew install cmake
+
+      - name: Run build
+        run: |
+          cmake -H. -Bbuild
+          cmake --build build -- -j2

--- a/libGraphite/quickdraw/internal/packbits.cpp
+++ b/libGraphite/quickdraw/internal/packbits.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "libGraphite/quickdraw/internal/packbits.hpp"
+#include <stdexcept>
 
 auto graphite::qd::packbits::decode(std::vector<uint8_t> &out_data, const std::vector<uint8_t>& pack_data, std::size_t value_size) -> std::size_t
 {


### PR DESCRIPTION
Related to https://github.com/EvocationGames/KestrelEngine/pull/46, this PR adds GitHub Actions workflows for Graphite that builds the project on macOS and Linux. Included in this PR is a commit fixing a missing include that the build caught on Linux.