### PR TITLE
Extend PICT support

### DIFF
--- a/libGraphite/quickdraw/internal/surface.cpp
+++ b/libGraphite/quickdraw/internal/surface.cpp
@@ -43,11 +43,17 @@ auto graphite::qd::surface::at(int x, int y) const -> graphite::qd::color
 
 auto graphite::qd::surface::set(int x, int y, graphite::qd::color color) -> void
 {
+    if (x >= m_width || y >= m_height) {
+        throw std::runtime_error("Attempted to set pixel beyond bounds of surface.");
+    }
     m_data[(y * m_width) + x] = color;
 }
 
 auto graphite::qd::surface::set(int offset, graphite::qd::color color) -> void
 {
+    if (offset >= m_data.size()) {
+        throw std::runtime_error("Attempted to set pixel beyond bounds of surface.");
+    }
     m_data[offset] = color;
 }
 

--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -138,7 +138,7 @@ auto graphite::qd::pict::read_indirect_bits_rect(graphite::data::reader& pict_re
         raw = read_bytes(pict_reader, row_bytes * height);
     }
     
-    pm.build_surface(m_surface, raw, color_table, m_size);
+    pm.build_surface(m_surface, raw, color_table, destination_rect);
     m_size += width * height;
 }
 

--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -101,6 +101,7 @@ auto graphite::qd::pict::read_pack_bits_rect(graphite::data::reader & pict_reade
     // Setup pixel buffer for raw values
     std::vector<uint8_t> raw;
     auto row_bytes = pm.row_bytes();
+    auto width = pm.bounds().width();
     auto height = pm.bounds().height();
     
     if (row_bytes >= 8) {
@@ -121,7 +122,8 @@ auto graphite::qd::pict::read_pack_bits_rect(graphite::data::reader & pict_reade
         raw = read_bytes(pict_reader, row_bytes * height);
     }
     
-    pm.build_surface(m_surface, raw, color_table);
+    pm.build_surface(m_surface, raw, color_table, m_size);
+    m_size += width * height;
 }
 
 auto graphite::qd::pict::read_direct_bits_rect(graphite::data::reader &pict_reader) -> void

--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -379,7 +379,6 @@ auto graphite::qd::pict::parse(graphite::data::reader& pict_reader) -> void
             auto rect = qd::rect::read(pict_reader, qd::rect::qd);
             m_x_ratio = static_cast<double>(m_frame.width()) / rect.width();
             m_y_ratio = static_cast<double>(m_frame.height()) / rect.height();
-            m_frame = rect;
         }
 
         if (m_x_ratio <= 0 || m_y_ratio <= 0) {

--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -138,6 +138,9 @@ auto graphite::qd::pict::read_indirect_bits_rect(graphite::data::reader& pict_re
         raw = read_bytes(pict_reader, row_bytes * height);
     }
     
+    auto origin = destination_rect.origin();
+    destination_rect.set_x(origin.x() - m_frame.origin().x());
+    destination_rect.set_y(origin.y() - m_frame.origin().y());
     pm.build_surface(m_surface, raw, color_table, destination_rect);
     m_size += width * height;
 }

--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -147,9 +147,8 @@ auto graphite::qd::pict::read_indirect_bits_rect(graphite::data::reader& pict_re
         raw = read_bytes(pict_reader, row_bytes * height);
     }
     
-    auto origin = destination_rect.origin();
-    destination_rect.set_x(origin.x() - m_frame.origin().x());
-    destination_rect.set_y(origin.y() - m_frame.origin().y());
+    destination_rect.set_x(destination_rect.x() - m_frame.origin().x());
+    destination_rect.set_y(destination_rect.y() - m_frame.origin().y());
     pm.build_surface(m_surface, raw, color_table, destination_rect);
     m_size += width * height;
 }

--- a/libGraphite/quickdraw/pict.hpp
+++ b/libGraphite/quickdraw/pict.hpp
@@ -27,6 +27,8 @@ namespace graphite::qd {
             direct_bits_rect = 0x009a,
             eof = 0x00ff,
             def_hilite = 0x001e,
+            op_color = 0x001f,
+            short_comment = 0x00a0,
             long_comment = 0x00a1,
             ext_header = 0x0c00,
             compressed_quicktime = 0x8200,
@@ -41,7 +43,6 @@ namespace graphite::qd {
         double m_x_ratio {};
         double m_y_ratio {};
         std::size_t m_size;
-        bool m_v1;
 
         auto parse(graphite::data::reader& pict_reader) -> void;
         auto read_region(graphite::data::reader& pict_reader) const -> graphite::qd::rect;

--- a/libGraphite/quickdraw/pict.hpp
+++ b/libGraphite/quickdraw/pict.hpp
@@ -22,6 +22,7 @@ namespace graphite::qd {
         {
             nop = 0x0000,
             clip_region = 0x0001,
+            bits_rect = 0x0090,
             pack_bits_rect = 0x0098,
             direct_bits_rect = 0x009a,
             eof = 0x00ff,
@@ -40,12 +41,13 @@ namespace graphite::qd {
         double m_x_ratio {};
         double m_y_ratio {};
         std::size_t m_size;
+        bool m_v1;
 
         auto parse(graphite::data::reader& pict_reader) -> void;
         auto read_region(graphite::data::reader& pict_reader) const -> graphite::qd::rect;
         auto read_long_comment(graphite::data::reader& pict_reader) -> void;
         auto read_direct_bits_rect(graphite::data::reader& pict_reader) -> void;
-        auto read_pack_bits_rect(graphite::data::reader & pict_reader) -> void;
+        auto read_indirect_bits_rect(graphite::data::reader& pict_reader, bool packed) -> void;
         auto read_compressed_quicktime(graphite::data::reader & pict_reader) -> void;
         auto read_uncompressed_quicktime(graphite::data::reader & pict_reader) -> void;
         auto read_image_description(graphite::data::reader & pict_reader) -> void;

--- a/libGraphite/quickdraw/pict.hpp
+++ b/libGraphite/quickdraw/pict.hpp
@@ -23,7 +23,9 @@ namespace graphite::qd {
             nop = 0x0000,
             clip_region = 0x0001,
             bits_rect = 0x0090,
+            bits_region = 0x0091,
             pack_bits_rect = 0x0098,
+            pack_bits_region = 0x0099,
             direct_bits_rect = 0x009a,
             eof = 0x00ff,
             def_hilite = 0x001e,
@@ -48,7 +50,7 @@ namespace graphite::qd {
         auto read_region(graphite::data::reader& pict_reader) const -> graphite::qd::rect;
         auto read_long_comment(graphite::data::reader& pict_reader) -> void;
         auto read_direct_bits_rect(graphite::data::reader& pict_reader) -> void;
-        auto read_indirect_bits_rect(graphite::data::reader& pict_reader, bool packed) -> void;
+        auto read_indirect_bits_rect(graphite::data::reader& pict_reader, bool packed, bool skip_region) -> void;
         auto read_compressed_quicktime(graphite::data::reader & pict_reader) -> void;
         auto read_uncompressed_quicktime(graphite::data::reader & pict_reader) -> void;
         auto read_image_description(graphite::data::reader & pict_reader) -> void;

--- a/libGraphite/quickdraw/pixmap.cpp
+++ b/libGraphite/quickdraw/pixmap.cpp
@@ -161,16 +161,17 @@ auto graphite::qd::pixmap::build_surface(
     std::shared_ptr<graphite::qd::surface> surface,
     const std::vector<uint8_t>& pixel_data,
     const qd::clut& clut,
-    int64_t offset) -> void
+    qd::rect destination) -> void
 {
     auto pixel_size = m_cmp_size * m_cmp_count;
+    auto origin = destination.origin();
     
     if (pixel_size == 8) {
         for (auto y = 0; y < m_bounds.height(); ++y) {
             auto y_offset = (y * m_row_bytes);
             for (auto x = 0; x < m_bounds.width(); ++x) {
                 auto byte = pixel_data[y_offset + x];
-                surface->set(offset++, clut.get(byte));
+                surface->set(origin.x() + x, origin.y() + y, clut.get(byte));
             }
         }
     }
@@ -185,7 +186,7 @@ auto graphite::qd::pixmap::build_surface(
                 auto byte = pixel_data[y_offset + (x / mod)];
                 auto byte_offset = diff - ((x % mod) * pixel_size);
                 auto v = (byte >> byte_offset) & mask;
-                surface->set(offset++, clut.get(v));
+                surface->set(origin.x() + x, origin.y() + y, clut.get(v));
             }
         }
     }

--- a/libGraphite/quickdraw/pixmap.cpp
+++ b/libGraphite/quickdraw/pixmap.cpp
@@ -163,19 +163,17 @@ auto graphite::qd::pixmap::build_surface(
     const qd::clut& clut,
     qd::rect destination) -> void
 {
-    auto orign = destination.origin();
-    auto size = destination.size();
-    if (pixel_data.size() < size.height() * m_row_bytes) {
+    if (pixel_data.size() < destination.height() * m_row_bytes) {
         throw std::runtime_error("Insufficent data to build surface from pixmap.");
     }
     auto pixel_size = m_cmp_size * m_cmp_count;
     
     if (pixel_size == 8) {
-        for (auto y = 0; y < size.height(); ++y) {
+        for (auto y = 0; y < destination.height(); ++y) {
             auto y_offset = (y * m_row_bytes);
-            for (auto x = 0; x < size.width(); ++x) {
+            for (auto x = 0; x < destination.width(); ++x) {
                 auto byte = pixel_data[y_offset + x];
-                surface->set(orign.x() + x, orign.y() + y, clut.get(byte));
+                surface->set(destination.x() + x, destination.y() + y, clut.get(byte));
             }
         }
     }
@@ -184,13 +182,13 @@ auto graphite::qd::pixmap::build_surface(
         auto mask = (1 << pixel_size) - 1;
         auto diff = 8 - pixel_size;
 
-        for (auto y = 0; y < size.height(); ++y) {
+        for (auto y = 0; y < destination.height(); ++y) {
             auto y_offset = (y * m_row_bytes);
-            for (auto x = 0; x < size.width(); ++x) {
+            for (auto x = 0; x < destination.width(); ++x) {
                 auto byte = pixel_data[y_offset + (x / mod)];
                 auto byte_offset = diff - ((x % mod) * pixel_size);
                 auto v = (byte >> byte_offset) & mask;
-                surface->set(orign.x() + x, orign.y() + y, clut.get(v));
+                surface->set(destination.x() + x, destination.y() + y, clut.get(v));
             }
         }
     }

--- a/libGraphite/quickdraw/pixmap.cpp
+++ b/libGraphite/quickdraw/pixmap.cpp
@@ -157,7 +157,11 @@ auto graphite::qd::pixmap::set_pm_table(const uint32_t& pm_table) -> void
 
 // MARK: -
 
-auto graphite::qd::pixmap::build_surface(std::shared_ptr<graphite::qd::surface> surface, const std::vector<uint8_t>& pixel_data, const qd::clut& clut) -> void
+auto graphite::qd::pixmap::build_surface(
+    std::shared_ptr<graphite::qd::surface> surface,
+    const std::vector<uint8_t>& pixel_data,
+    const qd::clut& clut,
+    int64_t offset) -> void
 {
     auto pixel_size = m_cmp_size * m_cmp_count;
     
@@ -166,7 +170,7 @@ auto graphite::qd::pixmap::build_surface(std::shared_ptr<graphite::qd::surface> 
             auto y_offset = (y * m_row_bytes);
             for (auto x = 0; x < m_bounds.width(); ++x) {
                 auto byte = pixel_data[y_offset + x];
-                surface->set(x, y, clut.get(byte));
+                surface->set(offset++, clut.get(byte));
             }
         }
     }
@@ -181,7 +185,7 @@ auto graphite::qd::pixmap::build_surface(std::shared_ptr<graphite::qd::surface> 
                 auto byte = pixel_data[y_offset + (x / mod)];
                 auto byte_offset = diff - ((x % mod) * pixel_size);
                 auto v = (byte >> byte_offset) & mask;
-                surface->set(x, y, clut.get(v));
+                surface->set(offset++, clut.get(v));
             }
         }
     }

--- a/libGraphite/quickdraw/pixmap.cpp
+++ b/libGraphite/quickdraw/pixmap.cpp
@@ -163,15 +163,19 @@ auto graphite::qd::pixmap::build_surface(
     const qd::clut& clut,
     qd::rect destination) -> void
 {
+    auto orign = destination.origin();
+    auto size = destination.size();
+    if (pixel_data.size() < size.height() * m_row_bytes) {
+        throw std::runtime_error("Insufficent data to build surface from pixmap.");
+    }
     auto pixel_size = m_cmp_size * m_cmp_count;
-    auto origin = destination.origin();
     
     if (pixel_size == 8) {
-        for (auto y = 0; y < m_bounds.height(); ++y) {
+        for (auto y = 0; y < size.height(); ++y) {
             auto y_offset = (y * m_row_bytes);
-            for (auto x = 0; x < m_bounds.width(); ++x) {
+            for (auto x = 0; x < size.width(); ++x) {
                 auto byte = pixel_data[y_offset + x];
-                surface->set(origin.x() + x, origin.y() + y, clut.get(byte));
+                surface->set(orign.x() + x, orign.y() + y, clut.get(byte));
             }
         }
     }
@@ -180,13 +184,13 @@ auto graphite::qd::pixmap::build_surface(
         auto mask = (1 << pixel_size) - 1;
         auto diff = 8 - pixel_size;
 
-        for (auto y = 0; y < m_bounds.height(); ++y) {
+        for (auto y = 0; y < size.height(); ++y) {
             auto y_offset = (y * m_row_bytes);
-            for (auto x = 0; x < m_bounds.width(); ++x) {
+            for (auto x = 0; x < size.width(); ++x) {
                 auto byte = pixel_data[y_offset + (x / mod)];
                 auto byte_offset = diff - ((x % mod) * pixel_size);
                 auto v = (byte >> byte_offset) & mask;
-                surface->set(origin.x() + x, origin.y() + y, clut.get(v));
+                surface->set(orign.x() + x, orign.y() + y, clut.get(v));
             }
         }
     }

--- a/libGraphite/quickdraw/pixmap.hpp
+++ b/libGraphite/quickdraw/pixmap.hpp
@@ -76,7 +76,7 @@ namespace graphite::qd {
             std::shared_ptr<graphite::qd::surface> surface,
             const std::vector<uint8_t>& pixel_data,
             const qd::clut& clut,
-            qd::rect destination = qd::rect(0, 0, 0, 0)
+            qd::rect destination
         ) -> void;
         auto build_pixel_data(const std::vector<uint16_t>& color_values, uint16_t pixel_size) -> std::shared_ptr<graphite::data::data>;
         auto write(graphite::data::writer& writer) -> void;

--- a/libGraphite/quickdraw/pixmap.hpp
+++ b/libGraphite/quickdraw/pixmap.hpp
@@ -76,7 +76,7 @@ namespace graphite::qd {
             std::shared_ptr<graphite::qd::surface> surface,
             const std::vector<uint8_t>& pixel_data,
             const qd::clut& clut,
-            int64_t offset = 0
+            qd::rect destination = qd::rect(0, 0, 0, 0)
         ) -> void;
         auto build_pixel_data(const std::vector<uint16_t>& color_values, uint16_t pixel_size) -> std::shared_ptr<graphite::data::data>;
         auto write(graphite::data::writer& writer) -> void;

--- a/libGraphite/quickdraw/pixmap.hpp
+++ b/libGraphite/quickdraw/pixmap.hpp
@@ -7,7 +7,9 @@
 
 #include <cstdint>
 #include "libGraphite/data/reader.hpp"
+#include "libGraphite/quickdraw/clut.hpp"
 #include "libGraphite/quickdraw/geometry.hpp"
+#include "libGraphite/quickdraw/internal/surface.hpp"
 #include "libGraphite/data/data.hpp"
 
 namespace graphite::qd {
@@ -70,6 +72,7 @@ namespace graphite::qd {
         auto set_cmp_size(const int16_t& cmp_size) -> void;
         auto set_pm_table(const uint32_t& pm_table) -> void;
 
+        auto build_surface(std::shared_ptr<graphite::qd::surface> surface, const std::vector<uint8_t>& pixel_data, const qd::clut& clut) -> void;
         auto build_pixel_data(const std::vector<uint16_t>& color_values, uint16_t pixel_size) -> std::shared_ptr<graphite::data::data>;
         auto write(graphite::data::writer& writer) -> void;
     };

--- a/libGraphite/quickdraw/pixmap.hpp
+++ b/libGraphite/quickdraw/pixmap.hpp
@@ -72,7 +72,12 @@ namespace graphite::qd {
         auto set_cmp_size(const int16_t& cmp_size) -> void;
         auto set_pm_table(const uint32_t& pm_table) -> void;
 
-        auto build_surface(std::shared_ptr<graphite::qd::surface> surface, const std::vector<uint8_t>& pixel_data, const qd::clut& clut) -> void;
+        auto build_surface(
+            std::shared_ptr<graphite::qd::surface> surface,
+            const std::vector<uint8_t>& pixel_data,
+            const qd::clut& clut,
+            int64_t offset = 0
+        ) -> void;
         auto build_pixel_data(const std::vector<uint16_t>& color_values, uint16_t pixel_size) -> std::shared_ptr<graphite::data::data>;
         auto write(graphite::data::writer& writer) -> void;
     };

--- a/libGraphite/quickdraw/ppat.cpp
+++ b/libGraphite/quickdraw/ppat.cpp
@@ -64,7 +64,7 @@ auto graphite::qd::ppat::parse(graphite::data::reader& reader) -> void
     // Now that all information has been extracted from the resource, proceed and attempt to render it.
     m_surface = std::make_shared<graphite::qd::surface>(m_pixmap.bounds().width(), m_pixmap.bounds().height());
 
-    m_pixmap.build_surface(m_surface, std::vector<uint8_t>(pmap_data.begin(), pmap_data.end()), m_clut);
+    m_pixmap.build_surface(m_surface, std::vector<uint8_t>(pmap_data.begin(), pmap_data.end()), m_clut, m_pixmap.bounds());
 }
 
 // MARK: - Encoder

--- a/libGraphite/quickdraw/ppat.cpp
+++ b/libGraphite/quickdraw/ppat.cpp
@@ -56,7 +56,7 @@ auto graphite::qd::ppat::parse(graphite::data::reader& reader) -> void
 
     reader.set_position(m_pat_base_addr);
     auto pmap_data_size = m_pixmap.row_bytes() * m_pixmap.bounds().height();
-    auto pmap_data = reader.read_data(pmap_data_size);
+    auto pmap_data = reader.read_bytes(pmap_data_size);
 
     reader.set_position(m_pixmap.pm_table());
     m_clut = qd::clut(reader);
@@ -64,72 +64,7 @@ auto graphite::qd::ppat::parse(graphite::data::reader& reader) -> void
     // Now that all information has been extracted from the resource, proceed and attempt to render it.
     m_surface = std::make_shared<graphite::qd::surface>(m_pixmap.bounds().width(), m_pixmap.bounds().height());
 
-    if (m_pixmap.cmp_size() == 1 && m_pixmap.cmp_count() == 1) {
-
-        for (auto y = 0; y < m_pixmap.bounds().height(); ++y) {
-            auto y_offset = (y * m_pixmap.row_bytes());
-
-            for (auto x = 0; x < m_pixmap.bounds().width(); ++x) {
-                auto byte_offset = 7 - (x % 8);
-
-                auto byte = pmap_data->at(y_offset + (x / 8));
-                auto v = (byte >> byte_offset) & 0x1;
-
-                m_surface->set(x, y, m_clut.get(v));
-            }
-        }
-
-    }
-    else if ((m_pixmap.cmp_size() == 1 && m_pixmap.cmp_count() == 2) || (m_pixmap.cmp_size() == 2 && m_pixmap.cmp_count() == 1)) {
-
-        for (auto y = 0; y < m_pixmap.bounds().height(); ++y) {
-            auto y_offset = (y * m_pixmap.row_bytes());
-
-            for (auto x = 0; x < m_pixmap.bounds().width(); ++x) {
-                auto byte_offset = (3 - (x % 4)) << 1;
-
-                auto byte = pmap_data->at(y_offset + (x / 4));
-                auto v = (byte >> byte_offset) & 0x3;
-
-                m_surface->set(x, y, m_clut.get(v));
-            }
-        }
-
-    }
-    else if ((m_pixmap.cmp_size() == 1 && m_pixmap.cmp_count() == 4) || (m_pixmap.cmp_size() == 4 && m_pixmap.cmp_count() == 1)) {
-
-        for (auto y = 0; y < m_pixmap.bounds().height(); ++y) {
-            auto y_offset = (y * m_pixmap.row_bytes());
-
-            for (auto x = 0; x < m_pixmap.bounds().width(); ++x) {
-                auto byte_offset = (1 - (x % 2)) << 2;
-
-                auto byte = pmap_data->at(y_offset + (x / 2));
-                auto v = (byte >> byte_offset) & 0xF;
-
-                m_surface->set(x, y, m_clut.get(v));
-            }
-        }
-
-    }
-    else if ((m_pixmap.cmp_size() == 1 && m_pixmap.cmp_count() == 8) || (m_pixmap.cmp_size() == 8 && m_pixmap.cmp_count() == 1)) {
-
-        for (auto y = 0; y < m_pixmap.bounds().height(); ++y) {
-            auto y_offset = (y * m_pixmap.row_bytes());
-
-            for (auto x = 0; x < m_pixmap.bounds().width(); ++x) {
-                auto byte = static_cast<uint8_t>(pmap_data->at(y_offset + x));
-
-                m_surface->set(x, y, m_clut.get(byte));
-            }
-        }
-
-    }
-    else {
-        throw std::runtime_error("Currently unsupported ppat configuration: cmp_size=" +
-                                 std::to_string(m_pixmap.cmp_size()) +
-                                 ", cmp_count=" + std::to_string(m_pixmap.cmp_count()));
-    }
+    m_pixmap.build_surface(m_surface, std::vector<uint8_t>(pmap_data.begin(), pmap_data.end()), m_clut);
 }
 
 // MARK: - Encoder


### PR DESCRIPTION
This PR extends PICT support in a number of ways:
- Adds support for pixmaps with < 8bpp.
- Adds support for v1 PICTs.
- Adds support for bits_rect, bits_region and packbits_region opcodes.
- Adheres to the destination rect to set pixels in the correct location.

[pict-tests.rsrc.zip](https://github.com/TheDiamondProject/Graphite/files/6179340/pict-tests.rsrc.zip)
