### PR TITLE
Add resource::set_data

### DIFF
--- a/libGraphite/rsrc/resource.cpp
+++ b/libGraphite/rsrc/resource.cpp
@@ -92,6 +92,11 @@ auto graphite::rsrc::resource::data() -> std::shared_ptr<graphite::data::data>
 	return m_data;
 }
 
+auto graphite::rsrc::resource::set_data(const std::shared_ptr<graphite::data::data>& data) -> void
+{
+	m_data = data;
+}
+
 // MARK: - 
 
 auto graphite::rsrc::resource::set_data_offset(const std::size_t& offset) -> void

--- a/libGraphite/rsrc/resource.hpp
+++ b/libGraphite/rsrc/resource.hpp
@@ -94,6 +94,11 @@ namespace graphite::rsrc {
     	 * Returns a shared pointer to the contained data.
     	 */
     	auto data() -> std::shared_ptr<graphite::data::data>;
+        
+    	/**
+    	 * Set the name of the resource.
+    	 */
+    	auto set_data(const std::shared_ptr<graphite::data::data>& data) -> void;
 
     	/**
     	 * Store the location of the data within the resource file.


### PR DESCRIPTION
The PR adds a function `graphite::rsrc::resource::set_data`, to allow setting a resource's data.