### PR TITLE
Validate bounds of data slice

### DIFF
--- a/libGraphite/data/data.cpp
+++ b/libGraphite/data/data.cpp
@@ -38,7 +38,9 @@ graphite::data::data::data(std::size_t capacity, enum graphite::data::data::byte
 graphite::data::data::data(std::shared_ptr<std::vector<char>> bytes, std::size_t size, std::size_t start, enum data::byte_order bo)
     : m_bo(bo), m_data(std::move(bytes)), m_size(size), m_start(start)
 {
-   	
+    if ((m_start + m_size) > m_data->size()) {
+        throw std::out_of_range("Invalid boundaries for data slice.");
+    }
 }
 
 // MARK: - Offset Calculations


### PR DESCRIPTION
This PR adds a validation check when creating a data slice from a vector. It prevents a potential crash when reading corrupt data.