### PR TITLE
Fix clut indices

### DIFF
--- a/libGraphite/quickdraw/clut.cpp
+++ b/libGraphite/quickdraw/clut.cpp
@@ -40,12 +40,12 @@ auto graphite::qd::clut::size() const -> int
 
 auto graphite::qd::clut::at(int index) const -> graphite::qd::color
 {
-    return std::get<1>(m_entries[index]);
+    return m_entries.at(index);
 }
 
 auto graphite::qd::clut::get(int value) const -> graphite::qd::color
 {
-    return std::get<1>(m_entries[value % m_size]);
+    return m_entries.at(value);
 }
 
 auto graphite::qd::clut::set(const qd::color& color) -> uint16_t
@@ -59,7 +59,7 @@ auto graphite::qd::clut::set(const qd::color& color) -> uint16_t
             ++value;
         }
     }
-    m_entries.emplace_back(std::make_tuple(value, color));
+    m_entries.emplace(value, color);
     m_size = m_entries.size();
     return value;
 }
@@ -71,15 +71,14 @@ auto graphite::qd::clut::parse(graphite::data::reader& reader) -> void
     m_seed = reader.read_long();
     m_flags = static_cast<flags>(reader.read_short());
     m_size = reader.read_short() + 1;
-    m_entries.resize(m_size, std::make_tuple(0, qd::color(0, 0, 0)));
 
     for (auto i = 0; i < m_size; ++i) {
         auto value = reader.read_short();
         auto r = static_cast<uint8_t>((reader.read_short() / 65535.0) * 255);
         auto g = static_cast<uint8_t>((reader.read_short() / 65535.0) * 255);
         auto b = static_cast<uint8_t>((reader.read_short() / 65535.0) * 255);
-        int index = m_flags == device ? i : (value % m_size);
-        m_entries[index] = std::make_tuple(value, qd::color(r, g, b));
+        int index = m_flags == device ? i : value;
+        m_entries.emplace(index, qd::color(r, g, b));
     }
 }
 

--- a/libGraphite/quickdraw/clut.hpp
+++ b/libGraphite/quickdraw/clut.hpp
@@ -6,8 +6,7 @@
 #define GRAPHITE_CLUT_HPP
 
 #include <string>
-#include <vector>
-#include <tuple>
+#include <map>
 #include "libGraphite/quickdraw/internal/color.hpp"
 #include "libGraphite/data/reader.hpp"
 #include "libGraphite/data/writer.hpp"
@@ -26,7 +25,7 @@ namespace graphite::qd {
         uint32_t m_seed { 0 };
         enum flags m_flags { pixmap };
         uint16_t m_size { 0 };
-        std::vector<std::tuple<uint16_t, qd::color>> m_entries;
+        std::map<uint16_t, qd::color> m_entries;
 
         auto parse(data::reader& reader) -> void;
 


### PR DESCRIPTION
This PR fixes a change made in #23 that turned out to be incorrect. To keep the performance benefits, it changes the clut entries vector to a map.
I've tested this for both parsing and writing, but are there any concerns you have with doing it this way?