### PR TITLE
More pict hacks

### DIFF
--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -341,7 +341,8 @@ auto graphite::qd::pict::read_image_description(graphite::data::reader &pict_rea
             comp.push_back(compressor >> 16);
             comp.push_back(compressor >> 8);
             comp.push_back(compressor);
-            throw std::runtime_error("Unsupported QuickTime compressor '" + comp + "' in PICT: " + std::to_string(m_id) + ", " + m_name);
+            throw std::runtime_error("Unsupported QuickTime compressor '" + comp + "' at offset " + std::to_string(pict_reader.position())
+                                     + " in PICT: " + std::to_string(m_id) + ", " + m_name);
     }
 }
 

--- a/libGraphite/quickdraw/pict.cpp
+++ b/libGraphite/quickdraw/pict.cpp
@@ -379,6 +379,10 @@ auto graphite::qd::pict::parse(graphite::data::reader& pict_reader) -> void
             auto rect = qd::rect::read(pict_reader, qd::rect::qd);
             m_x_ratio = static_cast<double>(m_frame.width()) / rect.width();
             m_y_ratio = static_cast<double>(m_frame.height()) / rect.height();
+            // This isn't strictly correct but it allows us to decode some images which
+            // would otherwise fail due to mismatched frame sizes. QuickDraw would normally
+            // scale such images down to fit the frame but here we just expand the frame.
+            m_frame.set_size(rect.size());
         }
 
         if (m_x_ratio <= 0 || m_y_ratio <= 0) {


### PR DESCRIPTION
Two changes here:
1. The frame size is set from the rect read in the extended header. This is a hack to allow decoding of some images which are larger than their frames (QuickDraw would normally downscale these). In the instances that I've encountered like this, the images really should be displayed at their native size but for whatever reason the frame size has been set incorrectly.
2. All QuickTime rle data is skipped, not just greyscale. I've added in a safety check to ensure we did actually find some real data, just in case the rle assumption isn't always true (though it is true in all instances I've encountered).