### PR TITLE
Allow 256 colours in cicn/ppat

### DIFF
--- a/libGraphite/quickdraw/cicn.cpp
+++ b/libGraphite/quickdraw/cicn.cpp
@@ -192,7 +192,7 @@ auto graphite::qd::cicn::data() -> std::shared_ptr<graphite::data::data>
                 color_values.emplace_back(m_clut.set(color));
             }
         }
-    } while(m_clut.size() >= 256);
+    } while(m_clut.size() > 256);
 
 
     // Determine what component configuration we need.

--- a/libGraphite/quickdraw/ppat.cpp
+++ b/libGraphite/quickdraw/ppat.cpp
@@ -104,7 +104,7 @@ auto graphite::qd::ppat::data() -> std::shared_ptr<graphite::data::data>
                 color_values.emplace_back(m_clut.set(color));
             }
         }
-    } while(m_clut.size() >= 256);
+    } while(m_clut.size() > 256);
 
 
     // Determine what component configuration we need.


### PR DESCRIPTION
This PR fixes a small issue where cicns & ppats were limited to 255 colours.