### PR TITLE
RleX packbits

### DIFF
--- a/libGraphite/spriteworld/rleX.cpp
+++ b/libGraphite/spriteworld/rleX.cpp
@@ -75,7 +75,7 @@ auto graphite::spriteworld::rleX::frame_count() const -> std::size_t
 
 auto graphite::spriteworld::rleX::data() -> data::block
 {
-    data::writer writer;
+    data::writer writer(data::byte_order::msb);
     encode(writer);
     return std::move(*const_cast<data::block *>(writer.data()));
 }
@@ -226,8 +226,6 @@ auto graphite::spriteworld::rleX::decode(data::reader &reader) -> void
 
 auto graphite::spriteworld::rleX::encode(data::writer &writer) -> void
 {
-    writer.change_byte_order(data::byte_order::lsb);
-
     // Write out the header
     m_frame_size.encode(writer, quickdraw::coding_type::macintosh);
     writer.write_short(m_bpp);
@@ -236,72 +234,81 @@ auto graphite::spriteworld::rleX::encode(data::writer &writer) -> void
 
     // Reserved fields.
     writer.write_short(0, 3);
+    
+    auto raw = m_surface.raw();
+    auto ch_data = data::block(m_frame_size.width * m_frame_size.height);
+    const auto pitch = m_surface.size().width * 4;
 
     // Write out the RLE frames
     for (auto f = 0; f < m_frame_count; ++f) {
         auto frame = frame_rect(f);
-
-        union quickdraw::ycbcr yuv {
-            .components.y = 0,
-            .components.cb = 128,
-            .components.cr = 128,
-            .components.alpha = 255
-        };
-
-        std::uint32_t count = 0;
-
-        for (std::int16_t y = 0; y < frame.size.height; ++y) {
-            for (std::int16_t x = 0; x < frame.size.width; ++x) {
-                auto next_yuv = quickdraw::ycbcr(m_surface.at(frame.origin.x + x, frame.origin.y + y));
-
-                if (next_yuv.value != yuv.value) {
-                    if (count > 0) {
-                        if (count < 256) {
-                            writer.write_enum(opcode::short_advance);
-                            writer.write_byte(count);
-                        } else {
-                            writer.write_enum(opcode::advance);
-                            writer.write_long(count);
-                        }
-                        count = 0;
-                    }
-
-                    if (next_yuv.components.y != yuv.components.y) {
-                        writer.write_enum(rleX::opcode::set_luma);
-                        writer.write_byte(next_yuv.components.y);
-                    }
-
-                    if (next_yuv.components.cr != yuv.components.cr) {
-                        writer.write_enum(rleX::opcode::set_cr);
-                        writer.write_byte(next_yuv.components.cr);
-                    }
-
-                    if (next_yuv.components.cb != yuv.components.cb) {
-                        writer.write_enum(rleX::opcode::set_cb);
-                        writer.write_byte(next_yuv.components.cb);
-                    }
-
-                    if (next_yuv.components.alpha != yuv.components.alpha) {
-                        writer.write_enum(rleX::opcode::set_alpha);
-                        writer.write_byte(next_yuv.components.alpha);
-                    }
-
-                    yuv.value = next_yuv.value;
+        for (auto ch = 0; ch < 4; ++ch) {
+            auto offset = frame.origin.y * pitch + frame.origin.x * 4 + ch;
+            auto ch_offset = 0;
+            for (std::int16_t y = 0; y < m_frame_size.height; ++y) {
+                for (std::int16_t x = 0; x < m_frame_size.width; ++x) {
+                    ch_data.set(raw.get<std::uint8_t>(offset+(x*4)), 1, ch_offset++);
                 }
-
-                count++;
+                offset += pitch;
             }
+            auto pos = writer.position();
+            writer.write_long(0);
+            auto size = compress(ch_data, writer);
+            writer.set_position(pos);
+            writer.write_long(size);
+            writer.move(size);
         }
-
-        if (count < 256) {
-            writer.write_enum(opcode::short_advance);
-            writer.write_byte(count);
-        }
-        else {
-            writer.write_enum(opcode::advance);
-            writer.write_long(count);
-        }
-
-        writer.write_enum(opcode::eof);
     }
+}
+
+auto graphite::spriteworld::rleX::compress(const data::block& uncompressed, data::writer &writer) -> std::size_t
+{
+    // Compress data using a variation of PackBits with extended repeats
+    const auto pos = writer.position();
+    auto offset = 0;
+    int64_t max = uncompressed.size() - 1;
+    // Trim trailing zeros
+    while (max >= 0 && uncompressed.get<std::uint8_t>(max) == 0) {
+        max--;
+    }
+    // We want to avoid breaking a literal to make a run of 2, as it would generally be less efficient
+    const auto max_minus_1 = max - 1;
+
+    while (offset <= max) {
+        auto run = 1;
+        auto replicate = uncompressed.get<std::uint8_t>(offset++);
+        // Repeated run, up to 4096
+        while (run < 0x1000 && offset <= max && uncompressed.get<std::uint8_t>(offset) == replicate) {
+            offset++;
+            run++;
+        }
+
+        if (run > 1) {
+            run -= 1;
+            if (run > 0x70) {
+                // 2 byte count. 4 high bits are on, remaining 12 bits hold the value.
+                writer.write_byte(0xF0 | (run >> 8));
+                writer.write_byte(run & 0xFF);
+            } else {
+                // Single byte count. High bit is on, remaining 7 bits hold the value.
+                writer.write_byte(0x80 | run);
+            }
+            writer.write_byte(replicate);
+            continue;
+        }
+        
+        // Literal run, up to 128
+        while (run < 0x80 && (offset == max
+                             || (offset < max && uncompressed.get<std::uint8_t>(offset) != uncompressed.get<std::uint8_t>(offset + 1))
+                             || (offset < max_minus_1 && uncompressed.get<std::uint8_t>(offset) != uncompressed.get<std::uint8_t>(offset + 2)))) {
+            offset++;
+            run++;
+        }
+
+        auto sliced = uncompressed.slice(offset-run, run);
+        writer.write_byte(run - 1);
+        writer.write_data(&sliced);
+    }
+    
+    return writer.position() - pos;
 }

--- a/libGraphite/spriteworld/rleX.hpp
+++ b/libGraphite/spriteworld/rleX.hpp
@@ -80,5 +80,7 @@ namespace graphite::spriteworld
         auto decode(data::reader& reader) -> void;
 
         [[nodiscard]] auto surface_offset(std::int32_t frame, std::int32_t offset) -> std::uint64_t;
+        
+        static auto compress(const data::block& uncompressed, data::writer &writer) -> std::size_t;
     };
 }


### PR DESCRIPTION
This uses a modified packbits implementation with extended repeats. My tests have shown notably smaller file sizes than current RleX, and it currently decodes around 10x faster too (on a >10MB sprite which I haven't attached here).
The surface has to be accessed via pointer since we're setting individual bytes, not entire colours. There's currently no bounds checking here, though I don't think there was before either.
The pack data is also accessed via pointer (rather than data reader) for better performance. Not sure if this is appropriate or not. I have at least added bounds checking here.

The attached file includes a sprite with two copies: The current opcode-based version and the packbits version.

[RleX Packbits.zip](https://github.com/TheDiamondProject/Graphite/files/9643889/RleX.Packbits.zip)
