### PR TITLE
Block memory changes

### DIFF
--- a/libGraphite/data/data.cpp
+++ b/libGraphite/data/data.cpp
@@ -300,7 +300,8 @@ __attribute__((optnone)) auto graphite::data::block::copy_from(const block &sour
 auto graphite::data::block::increase_size_to(std::size_t new_size) -> void
 {
     if (new_size > m_raw_size) {
-        throw std::runtime_error("Attempted to increase size of data::block beyond allowed range.");
+        m_raw_size = std::max(m_data_size * 2, new_size);
+        m_raw = m_data = realloc(m_raw, m_raw_size);
     }
     m_data_size = new_size;
 }

--- a/libGraphite/data/writer.cpp
+++ b/libGraphite/data/writer.cpp
@@ -57,21 +57,7 @@ auto graphite::data::writer::expand_storage(std::size_t amount) -> void
     // NOTE: We only allow resizing of data objects that we own.
     assert(m_owns_data);
 
-    // Construct a new data object with the appropriate new size, and copy in the old data.
-    auto required_size = size() + amount;
-    if (required_size < m_data->raw_size()) {
-        const_cast<class block *>(m_data)->increase_size_to(required_size);
-    }
-    else {
-        auto allocation_size = size() + std::max(size(), amount);
-        auto new_data = new class block(required_size, std::max(allocation_size, required_size), m_data->byte_order());
-        new_data->set(static_cast<uint32_t>(0), allocation_size);
-        new_data->copy_from(*m_data);
-
-        // Replace the old data with the new object.
-        delete m_data;
-        m_data = new_data;
-    }
+    const_cast<class block *>(m_data)->increase_size_to(size() + amount);
 
 }
 

--- a/libGraphite/quickdraw/support/surface.cpp
+++ b/libGraphite/quickdraw/support/surface.cpp
@@ -27,7 +27,7 @@ graphite::quickdraw::surface::surface(const quickdraw::size<std::int16_t> &size)
       m_row_bytes(size.width * constants::color_width),
       m_data(new data::block(size.width * size.height * constants::color_width))
 {
-    m_data->set(static_cast<std::uint32_t>(0), m_data->size());
+    m_data->clear();
 }
 
 graphite::quickdraw::surface::surface(std::int16_t width, std::int16_t height)
@@ -35,7 +35,7 @@ graphite::quickdraw::surface::surface(std::int16_t width, std::int16_t height)
       m_row_bytes(width * constants::color_width),
       m_data(new data::block(width * height * constants::color_width))
 {
-    m_data->set(static_cast<std::uint32_t>(0), m_data->size());
+    m_data->clear();
 }
 
 graphite::quickdraw::surface::surface(const quickdraw::size<std::int16_t>& size, union color color)
@@ -157,5 +157,5 @@ auto graphite::quickdraw::surface::set(std::uint32_t offset, union color color) 
 
 auto graphite::quickdraw::surface::clear() -> void
 {
-    m_data->set(colors::clear().value, m_data->size());
+    m_data->clear();
 }

--- a/libGraphite/spriteworld/rleD.cpp
+++ b/libGraphite/spriteworld/rleD.cpp
@@ -173,7 +173,7 @@ auto graphite::spriteworld::rleD::decode(data::reader &reader) -> void
 
     // Create the surface in which all frame will be draw to, and other working variables required to parse and decode
     // the RLE data correctly.
-    m_surface = quickdraw::surface(m_grid_size.width * m_frame_size.width, m_grid_size.height * m_frame_size.height, quickdraw::colors::clear());
+    m_surface = quickdraw::surface(m_grid_size.width * m_frame_size.width, m_grid_size.height * m_frame_size.height);
 
     rleD::opcode opcode = opcode::eof;
     std::uint64_t position = 0;

--- a/libGraphite/spriteworld/rleX.cpp
+++ b/libGraphite/spriteworld/rleX.cpp
@@ -326,7 +326,7 @@ auto graphite::spriteworld::rleX::decode(data::reader &reader) -> void
 
     // Create the surface in which all frames will be drawn to, and other working variables required to parse and
     // decode the RLE data correctly.
-    m_surface = quickdraw::surface(dim * m_frame_size.width, dim * m_frame_size.height, quickdraw::colors::clear());
+    m_surface = quickdraw::surface(dim * m_frame_size.width, dim * m_frame_size.height);
 
     std::uint32_t current_frame = 0;
     std::uint32_t count = 0;


### PR DESCRIPTION
I've split this out from the RleX PR. Maybe I'm doing something wrong (do I need any compiler settings to make simd work?) but I've found these changes improve performance for me.
- `block::set(uint8_t)` changed to use memset. `block::clear()` is also changed to take advantage of this, and `surface` now calls `block::clear()`. I've found this reduces the time taken to initialise a large surface in rleX. (Another possibility would be to use `calloc` in block construction.)
- `block::copy_from()` changed to use memcpy. I've found this reduces the time taken to expand storage in `writer`.
- `block::increase_size_to()` changed to use realloc when the size exceeds what has been allocated. `writer` now just calls this always instead of constructing a new block. I've found this further reduces the time taken to expand storage. (Not sure if there should be some simd alignment happening in here also, or if there are any other potential pitfalls.)