### PR TITLE
RleX QOI

### DIFF
--- a/libGraphite/spriteworld/rleX.hpp
+++ b/libGraphite/spriteworld/rleX.hpp
@@ -56,15 +56,14 @@ namespace graphite::spriteworld
         auto data() -> data::block;
 
     private:
-        enum class opcode : std::uint8_t
+        enum opcode : std::uint8_t
         {
-            eof = 0x00,
-            set_luma = 0x01,
-            set_cr = 0x02,
-            set_cb = 0x03,
-            set_alpha = 0x04,
-            advance = 0x05,
-            short_advance = 0x06,
+            index = 0b00 << 6,
+            diff  = 0b01 << 6,
+            luma  = 0b10 << 6,
+            run   = 0b11 << 6,
+            rgb   = 0b11111110,
+            rgba  = 0b11111111,
         };
 
         rsrc::resource::identifier m_id { 0 };
@@ -80,5 +79,8 @@ namespace graphite::spriteworld
         auto decode(data::reader& reader) -> void;
 
         [[nodiscard]] auto surface_offset(std::int32_t frame, std::int32_t offset) -> std::uint64_t;
+        
+        static auto compress(const quickdraw::surface& uncompressed, data::writer &writer) -> std::size_t;
+        static inline auto hash_color(const quickdraw::color color) -> std::uint8_t;
     };
 }


### PR DESCRIPTION
I've been learning about [QOI format](https://qoiformat.org) lately and thought it could be a great option for RleX so I put this together to try it out.
Pros of QOI:
- It's an existing, well-defined format with support in software such as imagemagick and ffmpeg.
- Compresses notably better than my previous "packbitsx" proposal.
- Is still very simple and very fast (this PR is similar in both line count and performance to the packbitsx PR).
- Has precedent for use in game engines (https://github.com/phoboslab/qoi#qoi-support-in-other-software).

Obviously a multi-frame RleX isn't quite the same as a QOI image file, so you can't just use other software to read and write it, but potentially QOI could also be used in Kestrel for static images (instead of PICT or TGA etc), in which case it could be helpful having a compatible bitstream.
On the other hand, if there's no reason to keep the bitstream compatible then there are some easy changes that could be made to make it better and/or faster.

Anyway, what do you think?